### PR TITLE
Fix RangeError in TimeGraphAxisScale

### DIFF
--- a/timeline-chart/src/components/time-graph-axis-scale.ts
+++ b/timeline-chart/src/components/time-graph-axis-scale.ts
@@ -65,7 +65,7 @@ export class TimeGraphAxisScale extends TimeGraphComponent<null> {
     }
 
     protected renderVerticalLines(drawLabels: boolean, lineColor: number, lineStyle: (label: string | undefined) => { lineHeight: number }) {
-        if (this.unitController.viewRangeLength > 0) {
+        if (this.unitController.viewRangeLength > 0 && this.stateController.canvasDisplayWidth > 0) {
             let labelWidth = 0;
             if (this.unitController.numberTranslator) {
                 const label = this.unitController.numberTranslator(this.unitController.viewRange.end);


### PR DESCRIPTION
Skip rendering vertical lines and tick labels when the chart width is 0,
this avoids division by zero in calculations.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>