### PR TITLE
Destroy TimeGraphLayer in one operation

### DIFF
--- a/timeline-chart/src/components/time-graph-arrow.ts
+++ b/timeline-chart/src/components/time-graph-arrow.ts
@@ -18,11 +18,7 @@ export class TimeGraphArrowComponent extends TimeGraphComponent<TimelineChart.Ti
         super(id, undefined, model);
 
         this.head = new PIXI.Graphics();
-    }
-
-    destroy() {
-        this.head.destroy();
-        super.destroy();
+        this._displayObject.addChild(this.head);
     }
 
     render(): void {
@@ -61,6 +57,5 @@ export class TimeGraphArrowComponent extends TimeGraphComponent<TimelineChart.Ti
         this.head.position.y = end.y;
         this.head.pivot = new PIXI.Point(end.x, end.y);
         this.head.rotation = Math.atan2(end.y - start.y, end.x - start.x);
-        this._displayObject.addChild(this.head);
     }
 }

--- a/timeline-chart/src/components/time-graph-component.ts
+++ b/timeline-chart/src/components/time-graph-component.ts
@@ -68,7 +68,7 @@ export abstract class TimeGraphComponent<T> {
     }
 
     destroy() {
-        this._displayObject.destroy();
+        this._displayObject.destroy({ children: true });
     }
 
     update(opts?: TimeGraphComponentOptions) {

--- a/timeline-chart/src/layer/time-graph-navigator.ts
+++ b/timeline-chart/src/layer/time-graph-navigator.ts
@@ -75,9 +75,11 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
             this.oldViewStart = this.unitController.viewRange.start;
             this.mouseIsDown = true;
             this.stateController.snapped = false;
+            document.addEventListener('snap-x-end', this._moveEndHandler);
         }
         this._moveEndHandler = () => {
             this.mouseIsDown = false;
+            document.removeEventListener('snap-x-end', this._moveEndHandler);
         }
         this.addEvent('mouseover', event => {
             if (this.stateController.snapped) {
@@ -99,7 +101,6 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
         }, this._displayObject);
         this.addEvent('mouseup', this._moveEndHandler, this._displayObject);
         this.addEvent('mouseupoutside', this._moveEndHandler, this._displayObject);
-        document.addEventListener('snap-x-end', this._moveEndHandler);
     }
 
     render(): void {
@@ -115,10 +116,6 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
             width,
             color: 0x777769
         })
-    }
-
-    destroy(): void {
-        document.removeEventListener('snap-x-end', this._moveEndHandler);
     }
 }
 


### PR DESCRIPTION
Add a child container to TimeGraphLayer. Add children to the child
container instead of the layer container.

Destroy the layer and its children graphics objects in one call instead
of destroying each child component one-by-one.

When removing all children, destroy the child container in one
operation, destroying all children graphics objects.

The TimeGraphComponent.destroy() method is no longer called recursively
on the child components when destroying the layer or removing all
children. Components are not expected to have any local resources to
release at destruction, other than the graphics object.

Make TimeGraphComponent.destroy() also destroy all children graphics
objects of the component in one operation. Remove the now unnecessary
override of destroy() in TimeGraphArrowComponent.

In TimeGraphNavigatorHandle, add document listener in the mouse down
handler, and remove the document listener in the mouse up handler.

Fixes https://github.com/eclipse-cdt-cloud/timeline-chart/issues/187.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>