### PR TITLE
Page scrolling on vertical and horizontal scrollbars

### DIFF
--- a/timeline-chart/src/components/time-graph-component.ts
+++ b/timeline-chart/src/components/time-graph-component.ts
@@ -1,6 +1,6 @@
 import * as PIXI from "pixi.js-legacy"
 
-export type TimeGraphInteractionType = 'mouseover' | 'mouseout' | 'mousemove' | 'mousedown' | 'mouseup' | 'mouseupoutside' | 'click';
+export type TimeGraphInteractionType = 'mouseover' | 'mouseout' | 'mousemove' | 'mousedown' | 'mouseup' | 'mouseupoutside' | 'rightdown' | 'click';
 export type TimeGraphInteractionHandler = (event: PIXI.InteractionEvent) => void;
 
 export type TimeGraphComponentOptions = {}

--- a/timeline-chart/src/layer/time-graph-navigator.ts
+++ b/timeline-chart/src/layer/time-graph-navigator.ts
@@ -12,6 +12,7 @@ export class TimeGraphNavigator extends TimeGraphLayer {
     protected navigatorBackground: TimeGraphNavigatorBackground;
     protected selectionRange?: TimeGraphRectangle;
     private _updateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (selectionRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; (selectionRange: TimelineChart.TimeGraphRange): void; };
+    private _contextMenuHandler: { (e: MouseEvent): void; (event: Event): void; };
 
     afterAddToContainer() {
         this._updateHandler = (): void => this.update();
@@ -21,6 +22,10 @@ export class TimeGraphNavigator extends TimeGraphLayer {
         this.navigatorHandle = new TimeGraphNavigatorHandle(this.unitController, this.stateController);
         this.addChild(this.navigatorHandle);
         this.unitController.onSelectionRangeChange(this._updateHandler);
+        this._contextMenuHandler = (e: MouseEvent): void => {
+            e.preventDefault();
+        }
+        this.onCanvasEvent('contextmenu', this._contextMenuHandler);
         this.update();
     }
 
@@ -56,6 +61,9 @@ export class TimeGraphNavigator extends TimeGraphLayer {
         if (this.unitController) {
             this.unitController.removeViewRangeChangedHandler(this._updateHandler);
             this.unitController.removeSelectionRangeChangedHandler(this._updateHandler);
+        }
+        if (this._contextMenuHandler) {
+            this.removeOnCanvasEvent('contextmenu', this._contextMenuHandler);
         }
         super.destroy();
     }
@@ -183,6 +191,7 @@ export class TimeGraphNavigatorBackground extends TimeGraphComponent<null> {
             };
         }, this._displayObject);
         
+        this.update()
     }
 
     protected toggleSnappedState = (bool: boolean) => {

--- a/timeline-chart/src/time-graph-row-controller.ts
+++ b/timeline-chart/src/time-graph-row-controller.ts
@@ -27,12 +27,33 @@ export class TimeGraphRowController {
         this.selectedRowChangedHandlers.push(handler);
     }
 
+    removeSelectedRowChangedHandler(handler: (row: TimelineChart.TimeGraphRowModel) => void) {
+        const index = this.selectedRowChangedHandlers.indexOf(handler);
+        if (index > -1) {
+            this.selectedRowChangedHandlers.splice(index, 1);
+        }
+    }
+
     onVerticalOffsetChangedHandler(handler: (verticalOffset: number) => void) {
         this.verticalOffsetChangedHandlers.push(handler);
     }
 
+    removeVerticalOffsetChangedHandler(handler: (verticalOffset: number) => void) {
+        const index = this.verticalOffsetChangedHandlers.indexOf(handler);
+        if (index > -1) {
+            this.verticalOffsetChangedHandlers.splice(index, 1);
+        }
+    }
+
     onTotalHeightChangedHandler(handler: (totalHeight: number) =>  void) {
         this.totalHeightChangedHandlers.push(handler);
+    }
+
+    removeTotalHeightChangedHandler(handler: (totalHeight: number) =>  void) {
+        const index = this.totalHeightChangedHandlers.indexOf(handler);
+        if (index > -1) {
+            this.totalHeightChangedHandlers.splice(index, 1);
+        }
     }
 
     get totalHeight(): number {


### PR DESCRIPTION
Implements page scrolling on horizontal and vertical scrollbars.  The user can right-click to move the navigator one page in the correct direction.

![screen-recorder-mon-may-02-2022-14-44-17](https://user-images.githubusercontent.com/98342456/166315050-8bd320e2-1c33-4715-bb51-c5298adde7d4.gif)

Updates comments and variable names on previous snap-on-click feature implementation for clarity.

Note: If testing in the timeline-chart example, right click will trigger a context menu.  This will not happen in the trace-viewer-extension, since the default is prevented onContextMenu.  You can disable context menu by opening the browser console and typing `window.oncontextmenu = e => e.preventDefault();`

Signed-off-by: Will Yang <william.yang@ericsson.com>