### PR TITLE
Fix missing row updates

### DIFF
--- a/timeline-chart/src/components/time-graph-row.ts
+++ b/timeline-chart/src/components/time-graph-row.ts
@@ -13,7 +13,7 @@ export interface TimeGraphRowStyle {
 
 export class TimeGraphRow extends TimeGraphComponent<TimelineChart.TimeGraphRowModel> implements TimeGraphParentComponent {
 
-    protected _providedModel: { range: TimelineChart.TimeGraphRange, resolution: number };
+    protected _providedModel: { range: TimelineChart.TimeGraphRange, resolution: number } | undefined;
     protected _rowStateComponents: Map<string, TimeGraphStateComponent> = new Map();
     protected _rowAnnotationComponents: Map<string, TimeGraphAnnotationComponent> = new Map();
 
@@ -123,7 +123,7 @@ export class TimeGraphRow extends TimeGraphComponent<TimelineChart.TimeGraphRowM
         return this._providedModel;
     }
 
-    set providedModel(providedModel: { range: TimelineChart.TimeGraphRange, resolution: number }) {
+    set providedModel(providedModel: { range: TimelineChart.TimeGraphRange, resolution: number } | undefined) {
         this._providedModel = providedModel;
     }
 }

--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -428,6 +428,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                     this.removeChild(rowComponent);
                 } else {
                     rowComponent.position.y = this.rowController.rowHeight * index;
+                    rowComponent.providedModel = undefined;
                 }
             });
             // update selected row


### PR DESCRIPTION
When the update flag in maybeFetchNewData() is set to true, it means all
rows must be refreshed (e.g. annotations might have changed). It was
only refreshing the visible rows, and when the other rows later became
visible they were considered valid and not refreshed.

Mark all existing rows as needing to be refreshed by setting their
providedModel object to undefined.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>