### PR TITLE
Add support for configurable location of time axis ticks

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -132,7 +132,7 @@ const timeGraphAxisContainer = new TimeGraphContainer({
 }, unitController, axisCanvas);
 axisHTMLContainer.appendChild(timeGraphAxisContainer.canvas);
 
-const timeAxisLayer = new TimeGraphAxis('timeGraphAxis', { color: styleConfig.naviBackgroundColor });
+const timeAxisLayer = new TimeGraphAxis('timeGraphAxis', { color: styleConfig.naviBackgroundColor, verticalAlign: 'bottom'});
 timeGraphAxisContainer.addLayers([timeAxisLayer]);
 
 const chartHTMLContainer = document.createElement('div');

--- a/timeline-chart/src/layer/time-graph-axis.ts
+++ b/timeline-chart/src/layer/time-graph-axis.ts
@@ -17,17 +17,21 @@ export class TimeGraphAxis extends TimeGraphLayer {
     private _keyUpHandler: { (event: KeyboardEvent): void; (this: Document, ev: KeyboardEvent): any; };
     private _keyDownHandler: { (event: KeyboardEvent): void; (this: Document, ev: KeyboardEvent): any; };
 
-    constructor(id: string, protected style?: { color?: number, lineColor?: number }) {
+    constructor(id: string, protected style?: { color?: number, lineColor?: number, verticalAlign?: string }) {
         super(id);
     }
 
     protected getOptions(): TimeGraphAxisStyle {
         let color;
         let lineColor;
+        let verticalAlign: string | undefined = 'top'; // Default position is top, same as CSS verticalAlign is 'baseline'
+        
         if (this.style) {
             color = this.style.color;
             lineColor = this.style.lineColor;
+            verticalAlign = this.style.verticalAlign;
         }
+
         return {
             height: this.stateController.canvasDisplayHeight,
             width: this.stateController.canvasDisplayWidth,
@@ -36,7 +40,8 @@ export class TimeGraphAxis extends TimeGraphLayer {
                 y: 0
             },
             color,
-            lineColor
+            lineColor,
+            verticalAlign
         }
     }
 


### PR DESCRIPTION
This commit adds support for configurable location of time axis ticks. Currently, the ticks can only be displayed above the time labels in the time axis, which do not make sense UI-wise when we have graphs that are displayed under the time axis. This commit allows the ticks of the time axis to be displayed dynamically either on top or under the time labels by adding a configuration parameter to the TimeGraphAxisScale component, so that developers can position the ticks correctly.

Resolve [Issue 203](https://github.com/eclipse-cdt-cloud/timeline-chart/issues/203) of the Theia Trace Extension. This also relates to [Issue 755](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/755) of the Theia Trace Extension. 

