### PR TITLE
Selected Row Visibility

### DIFF
--- a/timeline-chart/src/components/time-graph-row.ts
+++ b/timeline-chart/src/components/time-graph-row.ts
@@ -103,6 +103,7 @@ export class TimeGraphRow extends TimeGraphComponent<TimelineChart.TimeGraphRowM
     set style(style: TimeGraphRowStyle) {
         if (style.backgroundColor !== undefined) {
             this._options.color = style.backgroundColor;
+            this._style.backgroundColor = style.backgroundColor;
         }
         if (style.backgroundOpacity !== undefined) {
             this._style.backgroundOpacity = style.backgroundOpacity;


### PR DESCRIPTION
Adds public method TimelineChart#selectRowFromId that sets the selected
row using an ID number as a pointer.

Fixes a bug where background color information wasn't being stored
correctly for time-graph-row.

(I think some linting happened in this PR.  I will comment at the relevant changes.  I can re-create this branch without the linting changes as well.)

Fixes: #774, #772

Signed-off-by: Will Yang <william.yang@ericsson.com>