### PR TITLE
Remove zooming selection display object when fetching new data.

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -516,6 +516,10 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                         this.selectStateInNavigation();
                     }
                     if (this.mouseZooming) {
+                        if (this.zoomingSelection) {
+                            this.removeChild(this.zoomingSelection);
+                        }
+
                         delete this.zoomingSelection;
                         this.updateZoomingSelection();
                     }


### PR DESCRIPTION
To remove the zooming selection layer from the timeline chart, it is necessary to 1) remove the zooming selection object from the graph, and 2) delete the zooming selection object to reset it. Currently, when fetching new data, the code only performs step 2), but not 1). This leads to an issue where the zooming selection layer is not removed when users select a new zooming selection after zooming out. This commit adds step 1) so that when new data is fetched, the zooming selection is drawn and removed properly.

Fixes [Trace Compass Issue 839](https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/839)

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>