### PR TITLE
Truncate text until labels fit within states

### DIFF
--- a/timeline-chart/src/components/time-graph-state.ts
+++ b/timeline-chart/src/components/time-graph-state.ts
@@ -80,24 +80,28 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
 
         let textObjX = position.x + textPadding;
         const textObjY = position.y + textPadding;
-        let displayLabel = "";
 
         if (displayWidth > this.textWidth) {
             textObjX = position.x + (displayWidth - this.textWidth) / 2;
-            displayLabel = labelText;
+            this.textLabelObject.text = labelText
         }
         else {
+            let removeCount = 3; // Set to 3 because we need to append "..." to truncated text
             const textScaler = displayWidth / this.textWidth;
             const index = Math.min(Math.floor(textScaler * labelText.length), labelText.length - 1)
-            const partialLabel = labelText.substr(0, Math.max(index - 3, 0));
-            if (partialLabel.length > 0) {
-                displayLabel = partialLabel.concat("...");
-            }
+
+            do {
+                let displayLabel = "";
+                const partialLabel = labelText.substring(0, Math.max(index - removeCount, 0));
+                if (partialLabel.length > 0) {
+                    displayLabel = partialLabel.concat("...");
+                }
+                this.textLabelObject.text = displayLabel;
+                removeCount++;
+            } while (this.textLabelObject.getLocalBounds().width > displayWidth);
         }
 
-        this.textLabelObject.text = displayLabel;
-
-        if (displayLabel === "") {
+        if (this.textLabelObject.text === "") {
             return;
         }
 


### PR DESCRIPTION
When the timeline chart is zoom in/out, the label of each state will be modified to fit the width of the state. When the width of the state is smaller than the width of the label, the text is truncated. To determine how much text is truncated, the timeline chart uses the ratio of width of label text / width of state. However, since the width of each charater is different, this ratio does not well-represent how much text can be displayed in the label, causing text to overflow out of the state.

This commit tries to resolve the issue by truncating the label one letter at a time (after applying the ratio) until the label text fits within its state.

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>