### PR TITLE
Issue #895 Fix

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -496,7 +496,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
             // Only on coarse renders
             // Only if we are updating all rows and not increasing vertical height.  See: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/832#issuecomment-1259902534.
             const allRowsUpdated = rowIds.length === visibleRowIds.length;
-            const worldRange = (!fine && allRowsUpdated) ? this.unitController.updateWorldRangeFromViewRange() : this.unitController.worldRange;
+            const worldRange = allRowsUpdated ? this.unitController.updateWorldRangeFromViewRange() : this.unitController.worldRange;
             const request = { worldRange, resolution, rowIds };
             if (isEqual(request, this.ongoingRequest)) {
                 // request ignored because equal to ongoing request


### PR DESCRIPTION
Fixes https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/895

Previously, world range was not getting updated for fine-resolution updates.  Zooming in was always a fine-resolution update, so the world range stayed the same.  This is why nbTimes was becoming so large while zooming: the entire trace was always being fetched.

It's fine if we update the world range for fine-resolution updates.  I thought this was an optimization, but it doesn't actually do anything (besides bug the code).

World range now updates on fine-resolution calls to maybeFetchNewData and the bug seems to be resolved. 

Signed-off-by: Will Yang <william.yang@ericsson.com>