### PR TITLE
Grid line color update on theme change

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -9,6 +9,7 @@ import { TimeGraphRowController } from "../time-graph-row-controller";
 import { TimeGraphChartLayer } from "./time-graph-chart-layer";
 import { BIMath } from "../bigint-utils";
 import { debounce, cloneDeep, DebouncedFunc, isEqual } from 'lodash';
+import { TimeGraphLayerOptions } from "./time-graph-layer";
 
 export interface TimeGraphMouseInteractions {
     click?: (el: TimeGraphComponent<any>, ev: PIXI.InteractionEvent, clickCount: number) => void
@@ -371,9 +372,16 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         }
     }
 
-    update() {
+    update(opts: TimeGraphLayerOptions) {
+        this.updateRowLineColor(opts);
         this.updateScaleAndPosition();
         this._debouncedMaybeFetchNewData();
+    }
+    
+    updateRowLineColor(opts: TimeGraphLayerOptions) {
+        this.rowComponents.forEach(row => {
+            row.style = { ...row.style, ...opts };
+        })
     }
 
     updateZoomingSelection() {


### PR DESCRIPTION
This fixes a bug where the grid line colors were not updating on theme change.  This bug was likely introduced by the viewport implementation.

Grid lines are re-drawn explicitly when the theme changes.

Signed-off-by: Will Yang <william.yang@ericsson.com>