### PR TITLE
Update ubuntu version and node version in ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        node: [12]
+        os: [ubuntu-20.04]
+        node: [14]
 
     steps:
       - name: Checkout
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12]
+        node: [14]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The version of ubuntu is deprecated. Use 20.04 instead.

Also upgrade node version.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>