### PR TITLE
Rescale timeline-chart post zoom using PIXI.Container scale property

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -49,3 +49,57 @@ A reusable time axis component, that can be used independently of the other comp
 * Data can be fetched for a given resolution, so the provider can optimize the amount of data provided.
 * The data model provider allows to provide an array of rows, containing an array of elements. An element has a start time and a length. Arbitrary additional data can be provided, which is then used for styling and registered handlers. E.g., the hover provider would look up certain fields to display hover text.
 * The data model provider allows to provide an array of arrows, pointing from a point to another point. Here a point is a coordinate in the timeline graph consisting of a time and row number. Arrows can have arbitrary additional properties used for styling and registered handlers.
+
+## Performance improvements
+
+### Scaling
+
+Scaling of the timeline chart is done using the `scale factor` property of the state controller.
+
+* Any components that inherit from the `TimeGraphViewportLayer` can enable scaling using the `isScalable` property.
+* The `TimeGraphViewportLayer` applies the `scale factor` value to the `PIXI.Container.scale.x` property to scale the chart.
+* The `scale factor` is reset every time new data arrive from the server and the chart re-renders itself. A value of 1 means no scaling is applied.
+
+There are 2 ways to calculate this factor, which will be described below.
+
+#### On zoom
+
+The timeline chart clears all `row components` and re-render the states every time new data is fetched from the server. While waiting for the new data to arrive from the server, the timeline chart re-scales the states to make it look like the chart was zoomed in or out instantly the moment the view range changes. This section describes how the scaling is implemented to support view range changes triggered by zooming.
+
+When the view range is changed:
+
+* The `updateScaleFactor` function of the `state controller` of the timeline chart are triggered. It re-calculates the `scale factor` of the timeline chart.
+* Once the `scale factor` is updated, it will trigger the `onScaleFactorChange` event, upon which any components that are registered to this event can trigger their own handler.
+* In case of `view range` changes, the `scale factor` is calculated as `newScaleFactor = (oldViewRangeLength / newViewRangeLength) * oldScaleFactor`. The multiplication with the old scale factor is to support multiple zooming while waiting for data.
+
+Because the timeline chart requires the `oldViewRangeLength` to calculate the scale factor, the parameters of the `onViewRangeChanged` function has been updated:
+
+```text
+Previously: (viewRange)
+New implementation: (oldRange, newRange)
+With viewRange=newRange
+```
+
+**Important**: The `onViewRangeChanged()` handlers need to be removed when we destroy the timeline chart so that subsequent view range change event will not cause the error `cannot read property of undefined` (because all PIXI objects are destroyed).
+
+#### On resize
+
+When the timeline chart is resized, the `scale factor` is also recalculated:
+
+```text
+scaleFactor = canvasDisplayWidth / unscaledCanvasWidth;
+where
+canvasDisplayWidth = the current width of the canvas
+unscaledCanvasWidth = the width of the canvas when no scaling is applied
+```
+
+The `unscaledCanvasWidth` is updated whenever the chart is reset.
+
+#### Label text
+
+When the timeline chart is scaled, the label text will also be scaled. This squishes the text when the chart shrinks, and stretches the text when the chart expands. Thus, the timeline chart rescales the texts using the function `scaleLabel()` of the `TimeGraphStateComponent` to re-render the labels with an appropriate scaling factor so that the text size stays consistent.
+
+#### Note
+
+* Some components, such as the selection cursors, do not need to be scaled when the timeline chart is zoomed/resized, but rather re-rendered. In the case of cursors, if scaling is applied, the timeline chart will display a thick vertical line, which is not the expected behavior.
+* The `updateZoomingSelection()` function of the `TimeGraphChart` needs to undo the scaling to get the correct position of the user pointer.

--- a/timeline-chart/src/components/time-graph-grid.ts
+++ b/timeline-chart/src/components/time-graph-grid.ts
@@ -27,6 +27,6 @@ export class TimeGraphGrid extends TimeGraphAxisScale {
     }
 
     render(): void {
-        this.renderVerticalLines(false, this._options.lineColor || 0xdddddd, () => ({ lineHeight: this.stateController.canvasDisplayHeight }), true);
+        this.renderVerticalLines(false, this._options.lineColor || 0xdddddd, () => ({ lineHeight: this.stateController.canvasDisplayHeight }));
     }
 }

--- a/timeline-chart/src/components/time-graph-state.ts
+++ b/timeline-chart/src/components/time-graph-state.ts
@@ -10,6 +10,7 @@ export interface TimeGraphStateStyle {
     height?: number
     borderWidth?: number
     borderColor?: number
+    scale?: number
 }
 
 /**
@@ -71,7 +72,12 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
         };
     }
 
-    renderLabel() {
+    /**
+     * Conveniently generate the labels of states and apply proper scaling when zooming
+     *
+     * @param scaleFactor
+     */
+    renderLabel(scaleFactor: number = 1) {
         if (!this.model.label) {
             return;
         }
@@ -92,7 +98,7 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
         if (fontStyle) {
             const metrics = PIXI.TextMetrics.measureText(this.model.label, fontStyle);
             // Round the text width up just to be sure that it will fit in the state
-            const textWidth = Math.ceil(metrics.width * SCALING_FACTOR);
+            const textWidth = Math.ceil(metrics.width * SCALING_FACTOR / scaleFactor);
 
             let textObjX = position.x + textPadding;
             const textObjY = position.y + textPadding;
@@ -126,6 +132,18 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
             this.textLabelObject.alpha = this._options.opacity ?? 1;
             this.textLabelObject.x = textObjX;
             this.textLabelObject.y = textObjY;
+            this.textLabelObject.scale.x = 1 / scaleFactor;
+        }
+    }
+
+    /**
+     * Scale only state labels that actually have text displayed.
+     *
+     * @param scaleFactor
+     */
+    scaleLabel(scaleFactor?: number) {
+        if (this.textLabelObject && this.textLabelObject.scale && scaleFactor !== 1) {
+            this.renderLabel(scaleFactor);
         }
     }
 

--- a/timeline-chart/src/layer/time-graph-chart-arrows.ts
+++ b/timeline-chart/src/layer/time-graph-chart-arrows.ts
@@ -1,6 +1,7 @@
 import { TimeGraphArrowComponent, TimeGraphArrowCoordinates } from "../components/time-graph-arrow";
 import { TimeGraphElementPosition } from "../components/time-graph-component";
 import { TimelineChart } from "../time-graph-model";
+import { TimeGraphRowController } from "../time-graph-row-controller";
 import { TimeGraphChartLayer } from "./time-graph-chart-layer";
 
 export class TimeGraphChartArrows extends TimeGraphChartLayer {
@@ -9,9 +10,15 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
     protected rowIds: number[] = [];
     private _updateHandler: { (): void; (worldRange: TimelineChart.TimeGraphRange): void; (worldRange: TimelineChart.TimeGraphRange): void; };
 
+    constructor(id: string, protected rowController: TimeGraphRowController) {
+        super(id, rowController);
+        this.isScalable = false;
+    }
+
     protected afterAddToContainer() {
         this._updateHandler = (): void => this.update();
         this.stateController.onWorldRender(this._updateHandler);
+        this.stateController.onScaleFactorChange(this._updateHandler);
 
         this.rowController.onVerticalOffsetChangedHandler(verticalOffset => {
             this.layer.position.y = -verticalOffset;

--- a/timeline-chart/src/layer/time-graph-chart-cursors.ts
+++ b/timeline-chart/src/layer/time-graph-chart-cursors.ts
@@ -27,6 +27,7 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
 
     constructor(id: string, protected chartLayer: TimeGraphChart, protected rowController: TimeGraphRowController, style?: { color?: number }) {
         super(id, rowController);
+        this.isScalable = false;
         if (style && style.color) {
             this.color = style.color;
         }
@@ -154,6 +155,7 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
         this.onCanvasEvent('mousedown', this._mouseDownHandler);
         this.stateController.onWorldRender(this._updateHandler);
         this.unitController.onSelectionRangeChange(this._updateHandler);
+        this.stateController.onScaleFactorChange(this._updateHandler);
         this.update();
     }
 
@@ -232,6 +234,10 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
 
     update() {
         if (this.unitController.selectionRange) {
+            /**
+             * When user selects a range on the timeline chart, the selection position must correspond to the cursor of the user,
+             * and not the timeline chart itself since scaling might be applied.
+             */
             const firstCursorPosition = this.getWorldPixel(this.unitController.selectionRange.start);
             const secondCursorPosition = this.getWorldPixel(this.unitController.selectionRange.end);
             const firstCursorOptions = {

--- a/timeline-chart/src/layer/time-graph-chart-grid.ts
+++ b/timeline-chart/src/layer/time-graph-chart-grid.ts
@@ -1,9 +1,9 @@
-import { TimeGraphViewportLayer } from "./time-graph-viewport-layer";
 import { TimeGraphGrid } from "../components/time-graph-grid";
 import { TimelineChart } from "../time-graph-model";
 import { TimeGraphAxisLayerOptions } from "./time-graph-axis";
+import { TimeGraphLayer } from "./time-graph-layer";
 
-export class TimeGraphChartGrid extends TimeGraphViewportLayer {
+export class TimeGraphChartGrid extends TimeGraphLayer {
 
     protected gridComponent: TimeGraphGrid;
     private _updateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; (selectionRange: TimelineChart.TimeGraphRange): void; };;
@@ -22,6 +22,7 @@ export class TimeGraphChartGrid extends TimeGraphViewportLayer {
         this.addChild(this.gridComponent);
         this._updateHandler = (): void => this.update();
         this.stateController.onWorldRender(this._updateHandler);
+        this.unitController.onViewRangeChanged(this._updateHandler);
     }
 
     update(opts?: TimeGraphAxisLayerOptions) {
@@ -32,6 +33,7 @@ export class TimeGraphChartGrid extends TimeGraphViewportLayer {
         if (this.unitController) {
             this.stateController.removeWorldRenderHandler(this._updateHandler);
             this.unitController.removeSelectionRangeChangedHandler(this._updateHandler);
+            this.unitController.removeViewRangeChangedHandler(this._updateHandler);
         }
         super.destroy();
     }

--- a/timeline-chart/src/layer/time-graph-chart-selection-range.ts
+++ b/timeline-chart/src/layer/time-graph-chart-selection-range.ts
@@ -9,6 +9,7 @@ export class TimeGraphChartSelectionRange extends TimeGraphViewportLayer {
 
     constructor(id: string, style?: { color?: number }) {
         super(id);
+        this.isScalable = false;
         if (style && style.color) {
             this.color = style.color;
         }
@@ -34,6 +35,7 @@ export class TimeGraphChartSelectionRange extends TimeGraphViewportLayer {
         this._updateHandler = (): void => this.update();
         this.stateController.onWorldRender(this._updateHandler);
         this.unitController.onSelectionRangeChange(this._updateHandler);
+        this.stateController.onScaleFactorChange(this._updateHandler)
         this.update();
     }
 
@@ -44,6 +46,10 @@ export class TimeGraphChartSelectionRange extends TimeGraphViewportLayer {
 
     update() {
         if (this.unitController.selectionRange) {
+            /**
+             * When user selects a range on the timeline chart, the selection position must correspond to the cursor of the user,
+             * and not the timeline chart itself since scaling might be applied.
+             */
             const firstCursorPosition = this.getWorldPixel(this.unitController.selectionRange.start);
             const secondCursorPosition = this.getWorldPixel(this.unitController.selectionRange.end);
             if (secondCursorPosition !== firstCursorPosition) {

--- a/timeline-chart/src/layer/time-graph-viewport-layer.ts
+++ b/timeline-chart/src/layer/time-graph-viewport-layer.ts
@@ -4,6 +4,8 @@ import { TimeGraphStateController } from '../time-graph-state-controller';
 import { TimeGraphUnitController } from '../time-graph-unit-controller';
 
 export abstract class TimeGraphViewportLayer extends TimeGraphLayer {
+    // By default, scale this layer
+    protected isScalable: boolean = true;
 
     constructor(id: string) {
         super(id);
@@ -31,6 +33,7 @@ export abstract class TimeGraphViewportLayer extends TimeGraphLayer {
     initializeLayer(canvas: HTMLCanvasElement, stage: PIXI.Container, stateController: TimeGraphStateController, unitController: TimeGraphUnitController) {
         super.initializeLayer(canvas, stage, stateController, unitController);
         this.stateController.onPositionChanged(this.shiftStage);
+        this.stateController.onScaleFactorChange(this.scaleStage);
     }
 
     protected shiftStage = () => {
@@ -40,4 +43,10 @@ export abstract class TimeGraphViewportLayer extends TimeGraphLayer {
         this.layer.position.x = this.stateController.positionOffset.x;
     }
 
+    protected scaleStage = () => {
+        if (!this.isScalable || this.layer.scale === undefined || this.layer.scale === null) {
+            return;
+        }
+        this.layer.scale.x = this.stateController.scaleFactor;
+    }
 }

--- a/timeline-chart/src/time-graph-container.ts
+++ b/timeline-chart/src/time-graph-container.ts
@@ -122,6 +122,7 @@ export class TimeGraphContainer {
     destroy() {
         this.layers.forEach(l => l.destroy());
         this.unitController.removeViewRangeChangedHandler(this.calculatePositionOffset);
+        this.stateController.removeHandlers();
         this.application.destroy(true);
     }
 

--- a/timeline-chart/src/time-graph-unit-controller.ts
+++ b/timeline-chart/src/time-graph-unit-controller.ts
@@ -5,7 +5,7 @@ import { TimeGraphRenderController } from "./time-graph-render-controller";
 export class TimeGraphUnitController {
 
     
-    protected viewRangeChangedHandlers: ((newRange: TimelineChart.TimeGraphRange) => void)[];
+    protected viewRangeChangedHandlers: ((oldRange: TimelineChart.TimeGraphRange, newRange: TimelineChart.TimeGraphRange) => void)[];
     protected _viewRange: TimelineChart.TimeGraphRange;
     
     /**
@@ -41,19 +41,19 @@ export class TimeGraphUnitController {
         this._renderer = new TimeGraphRenderController();
     }
 
-    protected handleViewRangeChange() {
-        this.viewRangeChangedHandlers.forEach(handler => handler(this._viewRange));
+    protected handleViewRangeChange(oldRange: TimelineChart.TimeGraphRange) {
+        this.viewRangeChangedHandlers.forEach(handler => handler(oldRange, this._viewRange));
     }
 
     protected handleSelectionRangeChange() {
         this.selectionRangeChangedHandlers.forEach(handler => handler(this._selectionRange));
     }
 
-    onViewRangeChanged(handler: (viewRange: TimelineChart.TimeGraphRange) => void) {
+    onViewRangeChanged(handler: (oldRange: TimelineChart.TimeGraphRange, viewRange: TimelineChart.TimeGraphRange) => void) {
         this.viewRangeChangedHandlers.push(handler);
     }
 
-    removeViewRangeChangedHandler(handler: (viewRange: TimelineChart.TimeGraphRange) => void) {
+    removeViewRangeChangedHandler(handler: (oldRange: TimelineChart.TimeGraphRange, viewRange: TimelineChart.TimeGraphRange) => void) {
         const index = this.viewRangeChangedHandlers.indexOf(handler);
         if (index > -1) {
             this.viewRangeChangedHandlers.splice(index, 1);
@@ -82,6 +82,12 @@ export class TimeGraphUnitController {
         return this._viewRange;
     }
     set viewRange(newRange: TimelineChart.TimeGraphRange) {
+        // Making a deep copy
+        const oldRange = {
+            start: this._viewRange.start,
+            end: this._viewRange.end
+        };
+
         if (newRange.end > newRange.start) {
             this._viewRange = { start: newRange.start, end: newRange.end };
         }
@@ -91,7 +97,7 @@ export class TimeGraphUnitController {
         if (this._viewRange.end > this.absoluteRange) {
             this._viewRange.end = this.absoluteRange;
         }
-        this.handleViewRangeChange();
+        this.handleViewRangeChange(oldRange);
     }
 
     get worldRange(): TimelineChart.TimeGraphRange {


### PR DESCRIPTION
This commit uses PIXI.Container scale property to rescale the chart after each zoom in/zoom out to instead of the using the manually repositioning each elements in the chart to improve the performance of the timeline chart. The scale of the time-graph-chart is changed everytime the view range changes, and is reset once the server has replied to the front-end.

This commit removes the method updateScaleAndPosition(), which was used to manually rescaling the chart.

There are 3 use cases that are affected by this change:

[1] Zooming in and out using the mouse wheel
[2] Zooming in using the selection tool (right-click and drag)
[3] Zooming in using the action buttons (+/-) on the top right of the chart.