### PR TITLE
releng: Include date in version string for next versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "start": "lerna run start",
         "test": "lerna run test --",
         "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-        "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+        "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
     },
     "keywords": [
         "gantt",


### PR DESCRIPTION
This is to make sure -next versions sort properly so 'yarn upgrade' upgrades to valid newer versions.

fixes #253

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
