### PR TITLE
Scale annotations on change of time graph scale factor

### DIFF
--- a/timeline-chart/src/components/time-graph-annotation.ts
+++ b/timeline-chart/src/components/time-graph-annotation.ts
@@ -32,7 +32,9 @@ export class TimeGraphAnnotationComponent extends TimeGraphComponent<TimelineCha
         protected _options: TimeGraphAnnotationComponentOptions,
         protected _style: TimeGraphAnnotationStyle = { color: 0, size: 7, symbol: 'cross', verticalAlign: 'middle' },
         protected _row: TimeGraphRow,
-        displayObject?: PIXI.Graphics) {
+        protected scaleFactor: number,
+        displayObject?: PIXI.Graphics
+    ) {
         super(id, displayObject, model);
         this._size = _style.size || 7;
         // called to ensure consistency. Only the X component is used from options.
@@ -63,7 +65,7 @@ export class TimeGraphAnnotationComponent extends TimeGraphComponent<TimelineCha
     render(): void {
         const { symbol } = this._style as TimeGraphAnnotationStyle;
         const size = this._size;
-        const x = this._options.position.x;
+        const x = this._options.position.x * this.scaleFactor;
         const y = this._options.position.y;
 
         if (symbol === undefined || symbol == 'none') {
@@ -83,6 +85,19 @@ export class TimeGraphAnnotationComponent extends TimeGraphComponent<TimelineCha
             this.drawInvertedTriangle(x, y, size);
         } else {
             this.drawPlus(x, y, size);
+        }
+        this._displayObject.scale.x = 1 / this.scaleFactor;
+    }
+
+    /**
+     * Scale only annotations labels that actually have object displayed.
+     *
+     * @param scaleFactor
+     */
+    scaleAnnotation(scaleFactor: number) {
+        this.scaleFactor = scaleFactor;
+        if (this._displayObject && this._displayObject.scale) {
+            this.render();
         }
     }
 

--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -353,7 +353,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         this.unitController.onViewRangeChanged(this._debouncedMaybeFetchNewData);
 
         this._scaleFactorChangedHandler = () => {
-            this.scaleStateLabels();
+            this.scaleComponents();
         }
 
         this.stateController.onScaleFactorChange(this._scaleFactorChangedHandler);
@@ -738,7 +738,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         const start = this.getWorldPixel(annotation.range.start);
         let el: TimeGraphAnnotationComponent | undefined;
         const elementStyle = this.providers.rowAnnotationStyleProvider ? this.providers.rowAnnotationStyleProvider(annotation) : undefined;
-        el = new TimeGraphAnnotationComponent(annotation.id, annotation, { position: { x: start, y: rowComponent.position.y + (rowComponent.height * 0.5) } }, elementStyle, rowComponent);
+        el = new TimeGraphAnnotationComponent(annotation.id, annotation, { position: { x: start, y: rowComponent.position.y + (rowComponent.height * 0.5) } }, elementStyle, rowComponent, this.stateController.scaleFactor);
         return el;
     }
 
@@ -1011,13 +1011,19 @@ export class TimeGraphChart extends TimeGraphChartLayer {
 
     }
 
-    protected scaleStateLabels() {
+    protected scaleComponents() {
         this.rowComponents.forEach((rowComponent) => {
             const row = rowComponent.model;
-            row?.states.forEach((state: TimelineChart.TimeGraphState, elementIndex: number) => {
+            row?.states.forEach((state: TimelineChart.TimeGraphState) => {
                 const el = rowComponent.getStateById(state.id);
                 if (el) {
                     el.scaleLabel(this.stateController.scaleFactor);
+                }
+            });
+            row?.annotations.forEach((annotation: TimelineChart.TimeGraphAnnotation) => {
+                const el = rowComponent.getAnnotationById(annotation.id);
+                if (el) {
+                    el.scaleAnnotation(this.stateController.scaleFactor);
                 }
             });
         });


### PR DESCRIPTION
- Add the scale factor to the constructor and as a field of a time graph annotation. Use this scale factor when rendering the annotation.

- Rename scaleStateLabels() to scaleComponents() and make the method scale both state labels and annotations. This prevents annotations from being stretched or compressed on zoom.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>
