### PR TITLE
CI publish: Add release workflow/job, publish-latest job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,9 @@ on:
     branches:
       - master
   workflow_dispatch:
-
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -38,7 +40,7 @@ jobs:
           yarn
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
         shell: bash
@@ -47,7 +49,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
 
-  publish:
+  publish-next:
     needs: build
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'eclipse-cdt-cloud/timeline-chart'
 
@@ -75,7 +77,7 @@ jobs:
           yarn
         env:
           NODE_OPTIONS: --max_old_space_size=4096
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         uses: nick-invision/retry@v2
@@ -87,3 +89,39 @@ jobs:
           command: yarn publish:next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # The variable name comes from here: https://github.com/actions/setup-node/blob/70b9252472eee7495c93bb1588261539c3c2b98d/src/authutil.ts#L48
+
+  publish-latest:
+    needs: build
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'eclipse-cdt-cloud/timeline-chart'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Pre-Publish 
+        shell: bash
+        run: |
+          yarn
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 60
+          max_attempts: 3
+          retry_on: error
+          command: yarn publish:latest:ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # The variable name comes from here: https://github.com/actions/setup-node/blob/70b9252472eee7495c93bb1588261539c3c2b98d/src/authutil.ts#L48
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Create or prepare GitHub release
+
+on:
+  push:
+    branches:    
+      - master
+    paths:
+      - 'RELEASE'
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+    paths:
+      - 'RELEASE'
+
+jobs:
+  gh-release:
+    name: GitHub release
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pipe-cd/actions-gh-release@v2.6.0
+        with:
+          release_file: 'RELEASE'
+          # Actions that run using the auto-generated GitHub token are
+          # not allowed to trigger a new workflow run. In this case we want
+          # the tag created by actions-gh-release to re-trigger the main workflow
+          # and result in publishing the package to npm.
+          # The following scopes are required when creating the committer token:
+          #  - repo:status, repo_deployment, public_repo, read:org
+          # See here for more details:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.GH_COMMITTER_TOKEN }}
+            

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Time Graph
+# Time Graph - Developer's README
 
 [![Gitpod - Code Now][gitpod-icon-small]][gitpod-link]
 [![Build Status][build-status-icon]][build-status-link]
+
 
 A time graph / gantt chart library for large data (e.g. traces)
 
@@ -60,13 +61,48 @@ You can view an example [here](./timeline-chart/src/layer/__tests__/time-graph-c
 2. It is important to re-construct the timeline chart before each test to make sure the results are consistent.
 3. The tests themselves only print out the results and don't compare them to an actual value, because the threshold depends on the environment it runs. Therefore, make sure to output the performance measurement to the output console, so that it can be viewed once the tests finished running.
 
-## Test coverage
+### Test coverage
 
 The following command prints a coverage report to the terminal. As of now it covers all typescript files of the project, including those that are not supposed to have tests.
 
 ```shell
 yarn test --coverage --collectCoverageFrom='src/**/*.ts'
 ```
+
+## Release/publish
+
+Publishing of npm package and creating GitHub releases / git tags, all happen on GitHub CI.
+
+### Publish next package
+
+A `next` package is automatically published to `npm` every time a PR is merged.
+
+### publish latest / release
+
+Whenever a new release is desired, including publishing a corresponding `latest` package to `npm`, it can be triggered through a PR. The following has to be done:
+
+Create a new branch for your PR. e.g. 
+```bash
+git branch new-release && git checkout new-release
+```
+
+Then decide if the release shall be a `Major`, `Minor` or `Patch` release and use the corresponding command below to step packages versions, according to the release type. A new release commit will be created:
+
+``` bash
+yarn version:major
+# or
+yarn version:minor
+# or
+yarn version:patch
+```
+
+Modify the _version tag_ in file `./RELEASE`, to match the new release. Amend the release commit to include this change:
+
+```bash
+git add RELEASE && git commit --amend
+```
+
+Finally, push the branch and use it to create a PR. When the PR is merged, a GitHub release should be created with auto-generated release notes, as well as a git tag. Then the `publish-latest` CI job should trigger and if everything goes well, publish the new version of the package to `npm`.
 
 [build-status-icon]: https://github.com/eclipse-cdt-cloud/timeline-chart/workflows/CI-CD/badge.svg?branch=master
 [build-status-link]: https://github.com/eclipse-cdt-cloud/timeline-chart/actions?query=branch%3Amaster
@@ -75,7 +111,7 @@ yarn test --coverage --collectCoverageFrom='src/**/*.ts'
 [gitpod-icon-large]: https://gitpod.io/button/open-in-gitpod.svg
 [gitpod-icon-small]: https://img.shields.io/badge/Gitpod-code%20now-blue.svg?longCache=true
 [gitpod-link]: https://gitpod.io#https://github.com/eclipse-cdt-cloud/timeline-chart
-[sample-app]: https://github.com/theia-ide/theia-timeline-extension
+[sample-app]: https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/example/
 [screenshot-1]: https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot1-0.0.1.png
 [screenshot-2]: https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot2-0.0.1.png
 [trace-extension]: https://github.com/eclipse-cdt-cloud/theia-trace-extension

--- a/RELEASE
+++ b/RELEASE
@@ -1,0 +1,8 @@
+tag: v0.0.0
+
+commitInclude:
+  parentOfMergeCommit: true
+
+releaseNoteGenerator:
+  showAbbrevHash: true
+  showCommitter: false

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1,31 +1,38 @@
-# General Scope
+# Timeline-chart Library
+
 * The library is entirely client side, relying on the browser API.
 * Time is measured using number, so any kind of x measure unit can be used. 
 * A function translating numbers into human readable form for labels and hovers can be provided by the library user.
 * API for interaction with elements that will allow to register key and mouse listeners.
 * The components are styleable. Those parts that are implemented in HTML allow CSS for styling. The timeline view\u2019s contents (gantt chart) provide an API for styling
 
-# Components
-## Time Controller
+## Components
+
+### Time Controller
+
 * A central time controller that manages time-related properties, like the total time range, viewed range, time cursor positions.
 * It provides API for setting, reading and syncing the individual properties
 
-## Time Cursor
+### Time Cursor
+
 * Time Cursor T1 and optionally T2 are displayed as a vertical line spanning all rows. Range between T1 and T2 will be highlighted. Styling is configurable through CSS.
 * Time range selection (or range selection) has full read/write/listen API.
 * Rendering is configurable through CSS and separated from the actual data.
 Setting cursor T1 is doable by clicking anywhere in the main area. A mouse click while holding shift will set T2.
 View Port positions (use to scroll and zoom) has full read/write/listen API.
 
-## Time Axis
+### Time Axis
+
 A reusable time axis component, that can be used independently of the other components. It syncs with a time controller and allows the user to change the controllers values (zooming, scrolling, setting cursors)
+
 * The time axis is separated and usable alone, such that other widgets can render below and sync with the same time axis.
 * It is styleable through CSS.
 * A time axis controller is used to sync any number of widgets, so that scrolling in any of the timeline charts or the time axis will scroll all others accordingly.
 * Clicking and dragging on the time axis will increase/decrease the zoom
 * The view is connected to a time controller instance and sync its viewport, zoom level cursors bi-directionally
 
-## Timeline View
+### Timeline View
+
 * Shows data as a gantt chart on multiple rows. 
 * Optional labels can be shown in each state of each row.
 * Optional marker symbols can be drawn over the states.
@@ -43,7 +50,8 @@ A reusable time axis component, that can be used independently of the other comp
 * Horizontal zooming can be cancelled by pressing the `esc` button while zooming using the right click + drag.
 * The view is connected to a time controller instance and synchronizes its viewport, zoom level cursors bi-directionally.
 
-## Data Model
+### Data Model
+
 * Library user can configure a data model provider which gets asked for data lazily depending on the viewport.
 * Data is prefetched for x and y dimensions to make scrolling smoother.
 * Data can be fetched for a given resolution, so the provider can optimize the amount of data provided.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-    "version": "0.1.0",
     "private": true,
     "license": "MIT",
     "scripts": {
@@ -8,25 +7,15 @@
         "watch": "lerna run watch",
         "start": "lerna run start",
         "test": "lerna run test --",
-        "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
+        "publish:latest:ci": "lerna publish from-git --registry=https://registry.npmjs.org/ --exact --no-push --yes",
+        "publish:latest:manual": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push --yes",
         "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
+        "version:major": "lerna version major --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Major)\"",
+        "version:minor": "lerna version minor --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Minor)\"",
+        "version:patch": "lerna version patch --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Patch)\"",
         "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
         "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"
     },
-    "keywords": [
-        "gantt",
-        "timeline",
-        "tracing",
-        "trace"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/theia-ide/timeline-chart"
-    },
-    "bugs": {
-        "url": "https://github.com/theia-ide/timeline-chart/issues"
-    },
-    "homepage": "https://github.com/theia-ide/timeline-chart",
     "devDependencies": {
         "@eclipse-dash/nodejs-wrapper": "^0.0.1",
         "lerna": "^7.0.0",

--- a/timeline-chart/README.md
+++ b/timeline-chart/README.md
@@ -1,14 +1,19 @@
-## Description
+# timeline-chart
 
-A time graph / gantt chart library for large data (e.g. traces).
+A time graph / gantt chart library for large data (e.g. traces)
 
-## Additional Information
+## Documentation
 
-- [Documentation](https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/doc/documentation.md): Detailed description of the timeline-chart library and its components.
-- [Theia Trace Extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension): A reference application that uses the timeline-chart library.
+For detailed description of the `timeline-chart` library and it's components see [here][documentation].
+
+See also this [example application] that makes use of it.
 
 ## Screenshots
 
-![timeline-chart](https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot1-0.0.1.png)
-![timeline-chart](https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot2-0.0.1.png)
+![timeline-chart][screenshot-1]
+![timeline-chart][screenshot-2]
 
+[example application]: https://github.com/eclipse-cdt-cloud/timeline-chart/tree/master/example
+[documentation]: https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/doc/documentation.md
+[screenshot-1]: https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot1-0.0.1.png
+[screenshot-2]: https://raw.githubusercontent.com/eclipse-cdt-cloud/timeline-chart/master/doc/images/screenshot2-0.0.1.png

--- a/timeline-chart/package.json
+++ b/timeline-chart/package.json
@@ -1,6 +1,13 @@
 {
   "name": "timeline-chart",
   "version": "0.2.0",
+  "description": "A time graph / gantt chart library for large data (e.g. traces)",
+  "keywords": [
+    "gantt",
+    "timeline",
+    "tracing",
+    "trace"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "tsc",
@@ -26,5 +33,13 @@
     "jest-canvas-mock": "^2.3.1",
     "rimraf": "latest",
     "ts-jest": "^29.0.0"
+  },
+  "homepage": "https://github.com/eclipse-cdt-cloud/timeline-chart",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-cdt-cloud/timeline-chart"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-cdt-cloud/timeline-chart/issues"
   }
 }

--- a/timeline-chart/package.json
+++ b/timeline-chart/package.json
@@ -14,8 +14,7 @@
     "glob": "^7.1.6",
     "keyboard-key": "1.1.0",
     "lodash.throttle": "^4.1.1",
-    "pixi.js-legacy": "^5.3.3",
-    "rimraf": "latest"
+    "pixi.js-legacy": "^5.3.3"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.10",
@@ -25,6 +24,7 @@
     "enzyme-adapter-react-16": "^1.15.6",
     "jest": "^27.4.3",
     "jest-canvas-mock": "^2.3.1",
+    "rimraf": "latest",
     "ts-jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
The new release workflow uses action "pipe-cd/actions-gh-release". This action uses file RELEASE in the root. When that file is modified in a PR, and contains a new release tag, it will trigger a release upon the PR being merged. The action will create a git tag in the repo and the corresponding GitHub release, containing auto-generated release notes, that can be later edited by a committer.
    
The new release will in turn trigger the new "publish-latest" job (ci-cd workflow), which will publish the new version of the package to npm.

Also made misc improvements, e.g. in the package.json, README, ...

Note: it's expected that the "GitHub release" job will fail for now.

To test locally using e.g. `verdaccio`: 

Look at the release procedure added in the root (developer's) README, section "Release/publish". To test using a local registry, it's required to manually create the release tag (GitHub action `pipe-cd/actions-gh-release` does that in the workflow). I purposefully prevented `lerna` creating that tag \[1\] when running `yarn version:<release type>` to avoid creating a conflicting local tag on a commit that will possibly have a different SHA vs what gets merged, when creating the release PR. 

\[1\] by telling lerna to use a bogus command to create the tag: `--git-tag-command /usr/bin/true `