### PR TITLE
Release v0.3.0 (Minor)

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.0.0
+tag: v0.3.0
 
 commitInclude:
   parentOfMergeCommit: true

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-chart-example",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "lodash.throttle": "^4.1.1",
-    "timeline-chart": "^0.2.0"
+    "timeline-chart": "0.3.0"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "7.3.0",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/timeline-chart/package.json
+++ b/timeline-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-chart",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A time graph / gantt chart library for large data (e.g. traces)",
   "keywords": [
     "gantt",


### PR DESCRIPTION
Trigger a release (v0.3.0) to confirm our automated release/publish infrastructure is working as intended. This was done following these [instructions (README.md)](https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/README.md#publish-latest--release)

Upon merging this PR, we expect: 
- a `v0.3.0` GitHub release is created, with associated release notes (auto-generated)
- a `v0.3.0` git tag is created
- a `timeline-chart@0.3.0` package is published to npm