### PR TITLE
Do not package tests

### DIFF
--- a/timeline-chart/.npmignore
+++ b/timeline-chart/.npmignore
@@ -1,0 +1,4 @@
+unitTest
+__tests__
+jest.config.json
+tsconfig.json


### PR DESCRIPTION
Fixes #275

This commit adds a `.npmignore` file to help control what's not included in the `timeline-chart` npm package. With it, we now skip packaging the test, which should reduce the package size considerably.

Approx resulting package size (unpacked): from ~160M to ~600k:

![image](https://github.com/eclipse-cdt-cloud/timeline-chart/assets/25749063/42e1f720-fffc-4584-9201-3b4ef6f66279)
