### PR TITLE
Use node 18 for publish-latest job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16]
+        node: [18]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This one case was missed when we updated to node 18 a while ago.