### PR TITLE
Release v0.3.4 (Patch)

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.3.3
+tag: v0.3.4
 
 commitInclude:
   parentOfMergeCommit: true

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-chart-example",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "lodash.throttle": "^4.1.1",
-    "timeline-chart": "0.3.3"
+    "timeline-chart": "0.3.4"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "7.3.0",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/timeline-chart/package.json
+++ b/timeline-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-chart",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A time graph / gantt chart library for large data (e.g. traces)",
   "keywords": [
     "gantt",


### PR DESCRIPTION
Let's try this again - publish for v0.3.3 failed because a dependency required node 18 and the workflow was using node 16... Should work now. 