### PR TITLE
Clamp computed world range to absolute range

### DIFF
--- a/timeline-chart/src/time-graph-state-controller.ts
+++ b/timeline-chart/src/time-graph-state-controller.ts
@@ -168,8 +168,14 @@ export class TimeGraphStateController {
 
     computeWorldRangeFromViewRange() {
         const deltaV = this.unitController.viewRange.end - this.unitController.viewRange.start;
-        const start = this.unitController.viewRange.start - BIMath.multiply(deltaV, this.unitController.worldRenderFactor);
-        const end = this.unitController.viewRange.end + BIMath.multiply(deltaV, this.unitController.worldRenderFactor);
+        let start = this.unitController.viewRange.start - BIMath.multiply(deltaV, this.unitController.worldRenderFactor);
+        let end = this.unitController.viewRange.end + BIMath.multiply(deltaV, this.unitController.worldRenderFactor);
+        if (start < 0) {
+            start = BigInt(0);
+        }
+        if (end > this.unitController.absoluteRange) {
+            end = this.unitController.absoluteRange;
+        }
         return { start, end };
     }
 


### PR DESCRIPTION
Clamp the computed requested world range (which adds a buffer to the left and right of the view range) to the limits of the absolute range.

This prevents unnecessary row updates because the row's provided model range is always clamped.

Reject row data received during full search for an outdated world range.