### PR TITLE
[CI][workflows] Use node 20, 22 in workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [18, 20, 22]
 
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18]
+        node: [20]
 
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/license-check-workflow.yml
+++ b/.github/workflows/license-check-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
         java: [11]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Add node 20,22 for build and tests (keep 18 for now). Use 20 for publish and license check.

The idea is to start exercising node 22 and use node 20 as default for most things. We keep node 18 for build and tests for now but intend to remove it once it's EoL.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
