### PR TITLE
[license check] change batch size from 50 to 500

### DIFF
--- a/configs/license-check-config.json
+++ b/configs/license-check-config.json
@@ -2,7 +2,7 @@
     "project": "ecd.cdt-cloud",
     "review": false,
     "inputFile": "yarn.lock",
-    "batch": 50,
+    "batch": 500,
     "timeout": 200,
     "summary": "license-check-summary.txt"
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The batch size is used by dash-licenses, and determines how many dependencies are sent per request to the Eclipse Foundation and ClearlyDefined servers. 500 is actually the default when running plain dash-licenses, and will result in fewer requests which could help with `HTTP 429` error we see once in a while, specially on the ClearlyDefined requests, that causes the license check CI job to fail.

See:
https://github.com/eclipse-dash/dash-licenses/issues/301#issuecomment-2704821657

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the license check locally and confirm the new batch size of 500 is used (it will be mentioned in the printouts):
$ yarn --ignore-scripts && yarn license:check

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template