### PR TITLE
[WebGL] Make it optional to use WebGL when creating TimeGraphContainer

### DIFF
--- a/timeline-chart/src/time-graph-container.ts
+++ b/timeline-chart/src/time-graph-container.ts
@@ -12,6 +12,7 @@ export interface TimeGraphContainerOptions {
     lineColor?: number;
     transparent?: boolean;
     classNames?: string;
+    forceCanvasRenderer?: boolean;
 }
 
 export class TimeGraphContainer {
@@ -36,7 +37,8 @@ export class TimeGraphContainer {
             canvas = extCanvas;
         }
 
-        const noWebgl2 = !PIXI.utils.isWebGLSupported() || !canvas.getContext('webgl2');
+        const supported = PIXI.utils.isWebGLSupported();
+        const noWebgl2 = !supported || config.forceCanvasRenderer || !canvas.getContext('webgl2');
         canvas.style.width = config.width + 'px';
         canvas.style.height = config.height + 'px';
         canvas.width = config.width;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/timeline-chart/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Added an entry to TimeGraphContainerOptions, that the caller can use to request that no WebGL context be used for the new TimeGraphContainer:

`noWebGl?: boolean`

This can be used when the container is known in advance to be lightweight in terms of rendering, and that using one of a limited number of available WebGL contexts for it, is not the potential performance gain.

### How to test
Confirm CI passes

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
Once this is merged and released, consumer like the react components package in theia-trace-extension can be updated to use this, declining that a WebGL context be used for some of the time graph containers it creates, thus sparing the limited WebGL contexts. See Draft PR: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1206

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
